### PR TITLE
feat: add classes for syndication polygon and point

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.GrAr.Legacy/SpatialTools/SyndicationPoint.cs
+++ b/src/Be.Vlaanderen.Basisregisters.GrAr.Legacy/SpatialTools/SyndicationPoint.cs
@@ -1,0 +1,19 @@
+namespace Be.Vlaanderen.Basisregisters.GrAr.Legacy.SpatialTools
+{
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Een GML3 punt of een GeoJSON punt, afhankelijk van het Content-Type.
+    /// </summary>
+    [DataContract(Name = "Positie", Namespace = "")]
+    public class SyndicationPoint
+    {
+        /// <summary>
+        /// Een GML3 punt.
+        /// </summary>
+        [DataMember(Name = "point")]
+        [JsonIgnore]
+        public GmlPoint XmlPoint { get; set; }
+    }
+}

--- a/src/Be.Vlaanderen.Basisregisters.GrAr.Legacy/SpatialTools/SyndicationPolygon.cs
+++ b/src/Be.Vlaanderen.Basisregisters.GrAr.Legacy/SpatialTools/SyndicationPolygon.cs
@@ -1,0 +1,19 @@
+namespace Be.Vlaanderen.Basisregisters.GrAr.Legacy.SpatialTools
+{
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Een GML3 punt of een GeoJSON punt, afhankelijk van het Content-Type.
+    /// </summary>
+    [DataContract(Name = "GeometriePolygoon", Namespace = "")]
+    public class SyndicationPolygon
+    {
+        /// <summary>
+        /// Een GML3 polygon.
+        /// </summary>
+        [JsonIgnore]
+        [DataMember(Name = "polygon")]
+        public GmlPolygon XmlPolygon { get; set; }
+    }
+}


### PR DESCRIPTION
When using the `Point` and `Polygon` classes the `DataContractSerializer` throws an exception saying it's not allowed for 2 members with same name (eg. `point`).

Called from: https://github.com/Informatievlaanderen/grar-common/blob/7fefadf2ccc77d6425da668c9e2e52762c7b31a0/src/Be.Vlaanderen.Basisregisters.GrAr.Common/Syndication/SyndicationContentBase.cs#L10