### PR TITLE
fix: fixing naming

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.GrAr.Import/Processing/CrabImport/CrabImportContext.cs
+++ b/src/Be.Vlaanderen.Basisregisters.GrAr.Import/Processing/CrabImport/CrabImportContext.cs
@@ -12,11 +12,22 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Import.Processing.CrabImport
         private readonly CrabImportSchema _crabImportSchema;
         public DbSet<ImportBatchStatus> BatchStatuses { get; set; }
 
-        public ImportBatchStatus LastBatchFor(ImportFeed feed) =>
-            BatchStatuses
+        public BatchStatus LastBatchFor(ImportFeed feed)
+        {
+            var lastStatus = BatchStatuses
                 ?.Where(status => status.ImportFeedId == feed.Id)
                 .OrderBy(status => status.From)
                 .LastOrDefault();
+
+            return lastStatus == null
+                ? null
+                : new BatchStatus
+                {
+                    From = lastStatus.From,
+                    Until = lastStatus.Until,
+                    Completed = lastStatus.Completed
+                };
+        }
 
         public void SetCurrent(BatchStatusUpdate status)
         {

--- a/src/Be.Vlaanderen.Basisregisters.GrAr.Import/Processing/ImportFeed.cs
+++ b/src/Be.Vlaanderen.Basisregisters.GrAr.Import/Processing/ImportFeed.cs
@@ -8,5 +8,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Import.Processing
 
         [JsonIgnore]
         public string Id => Name?.ToLowerInvariant().Trim() ?? string.Empty;
+
+        public static explicit operator ImportFeed(string name) => new ImportFeed { Name = name };
     }
 }


### PR DESCRIPTION
BREAKING CHANGE:
- rename configuration calls to be inline with excisting calls
- changed type of LastStatusFor(0ImportFeed) so the ef record type is
not passed

--
Breaking change required as the last  breaking change was not picked
up by sematic versioning  
- [ ] Unlist version 8.2 from nuget

