### PR TITLE
fix: replace import feed id by making name lowercase

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.GrAr.Import/Processing/CrabImport/CrabImportContext.cs
+++ b/src/Be.Vlaanderen.Basisregisters.GrAr.Import/Processing/CrabImport/CrabImportContext.cs
@@ -15,7 +15,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Import.Processing.CrabImport
         public BatchStatus LastBatchFor(ImportFeed feed)
         {
             var lastStatus = BatchStatuses
-                ?.Where(status => status.ImportFeedId == feed.Id)
+                ?.Where(status => status.ImportFeedId == feed.Name)
                 .OrderBy(status => status.From)
                 .LastOrDefault();
 
@@ -34,16 +34,16 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Import.Processing.CrabImport
             if (status == null)
                 return;
 
-            if (status.Until == DateTime.MinValue || string.IsNullOrWhiteSpace(status.ImportFeed?.Id))
+            if (status.Until == DateTime.MinValue || string.IsNullOrWhiteSpace(status.ImportFeed?.Name))
                 throw new ArgumentException($"Invalid batch status : {JsonConvert.SerializeObject(status)}");
 
-            var currentStatus = BatchStatuses.Find(status.From, status.ImportFeed.Id);
+            var currentStatus = BatchStatuses.Find(status.From, status.ImportFeed.Name);
             if (currentStatus == null)
             {
                 BatchStatuses.Add(
                     new ImportBatchStatus
                     {
-                        ImportFeedId = status.ImportFeed.Id,
+                        ImportFeedId = status.ImportFeed.Name,
                         From = status.From,
                         Until = status.Until,
                         Completed = status.Completed

--- a/src/Be.Vlaanderen.Basisregisters.GrAr.Import/Processing/ImportFeed.cs
+++ b/src/Be.Vlaanderen.Basisregisters.GrAr.Import/Processing/ImportFeed.cs
@@ -1,13 +1,14 @@
 namespace Be.Vlaanderen.Basisregisters.GrAr.Import.Processing
 {
-    using Newtonsoft.Json;
-
     public class ImportFeed
     {
-        public string Name { get; set; }
+        private string _lowercasedName;
 
-        [JsonIgnore]
-        public string Id => Name?.ToLowerInvariant().Trim() ?? string.Empty;
+        public string Name
+        {
+            get => _lowercasedName;
+            set => _lowercasedName = value?.ToLowerInvariant().Trim() ?? string.Empty;
+        }
 
         public static explicit operator ImportFeed(string name) => new ImportFeed { Name = name };
     }


### PR DESCRIPTION
Cleans up some of the messy code for `ImportFeed`

`Id` was not serialized, so it would only break the direct usuage. 
Not worth bumping the major version, but this way it's already cleanen up.