### PR TITLE
feat: change isnapshotmanager interface to accept eventhash

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.GrAr.Oslo/SnapshotProducer/ISnapshotManager.cs
+++ b/src/Be.Vlaanderen.Basisregisters.GrAr.Oslo/SnapshotProducer/ISnapshotManager.cs
@@ -6,6 +6,6 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Oslo.SnapshotProducer
 
     public interface ISnapshotManager
     {
-        Task<OsloResult?> FindMatchingSnapshot(string objectId, Instant eventVersion, long eventPosition, bool throwStaleWhenGone, CancellationToken ct);
+        Task<OsloResult?> FindMatchingSnapshot(string objectId, Instant eventVersion, string? eventHash, long eventPosition, bool throwStaleWhenGone, CancellationToken ct);
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.GrAr.Oslo/SnapshotProducer/OsloProxy.cs
+++ b/src/Be.Vlaanderen.Basisregisters.GrAr.Oslo/SnapshotProducer/OsloProxy.cs
@@ -40,6 +40,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Oslo.SnapshotProducer
             }
 
             osloResult.JsonContent = jsonContent;
+            osloResult.ETag = response.Headers.ETag?.Tag.Trim('"');
 
             return osloResult;
         }

--- a/src/Be.Vlaanderen.Basisregisters.GrAr.Oslo/SnapshotProducer/OsloResult.cs
+++ b/src/Be.Vlaanderen.Basisregisters.GrAr.Oslo/SnapshotProducer/OsloResult.cs
@@ -12,6 +12,9 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Oslo.SnapshotProducer
 
         [JsonIgnore]
         public string JsonContent { get; set; }
+
+        [JsonIgnore]
+        public string? ETag { get; set; }
     }
 
     public class OsloIdentificator : Identificator

--- a/src/Be.Vlaanderen.Basisregisters.GrAr.Oslo/SnapshotProducer/SnapshotManager.cs
+++ b/src/Be.Vlaanderen.Basisregisters.GrAr.Oslo/SnapshotProducer/SnapshotManager.cs
@@ -31,6 +31,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Oslo.SnapshotProducer
         public async Task<OsloResult?> FindMatchingSnapshot(
             string objectId,
             Instant eventVersion,
+            string? eventHash,
             long eventPosition,
             bool throwStaleWhenGone,
             CancellationToken ct)
@@ -96,6 +97,13 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Oslo.SnapshotProducer
                 if (versionDeltaInSeconds > 0)
                 {
                     throw new StaleSnapshotException();
+                }
+
+                if (snapshot.ETag is not null && eventHash is not null)
+                {
+                    return versionDeltaInSeconds == 0 && snapshot.ETag == eventHash
+                        ? snapshot
+                        : null;
                 }
 
                 return versionDeltaInSeconds == 0

--- a/test/Be.Vlaanderen.Basisregisters.GrAr.Tests/Oslo/SnapshotManagerTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.GrAr.Tests/Oslo/SnapshotManagerTests.cs
@@ -24,6 +24,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Tests.Oslo
             var result = await snapshotManager.FindMatchingSnapshot(
                 "50083",
                 Instant.FromDateTimeOffset(DateTimeOffset.Parse("2022-03-23T14:24:04+01:00")),
+                null,
                 eventPosition: 1111111,
                 throwStaleWhenGone: false,
                 CancellationToken.None);
@@ -53,6 +54,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Tests.Oslo
             var result = snapshotManager.FindMatchingSnapshot(
                 "50083",
                 Instant.FromDateTimeOffset(DateTimeOffset.Parse(eventVersion)),
+                null,
                 eventPosition: 1111111,
                 throwStaleWhenGone: false,
                 CancellationToken.None);
@@ -60,6 +62,78 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Tests.Oslo
             Task.WaitAny(new Task[] { result }, ct.Token);
 
             result.Result.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void WhenVersionsMatch_AndETagMatch_ThenReturnOsloResult()
+        {
+            var eventHash = "eventHash";
+            var eTag = eventHash;
+
+            var eventVersion = "2022-03-23T14:24:04.801+01:00";
+            var snapshotVersion = "2022-03-23T14:24:04+01:00";
+
+            var ct = new CancellationTokenSource(5000);
+
+            var mockProxy = new Mock<IOsloProxy>();
+            mockProxy.Setup(x => x.GetSnapshot(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new OsloResult
+                {
+                    ETag = eTag,
+                    Identificator = new OsloIdentificator
+                    {
+                        Versie = snapshotVersion
+                    }
+                });
+
+            var snapshotManager = new SnapshotManager(new NullLoggerFactory(), mockProxy.Object, SnapshotManagerOptions.Create("1", "1"));
+            var result = snapshotManager.FindMatchingSnapshot(
+                "50083",
+                Instant.FromDateTimeOffset(DateTimeOffset.Parse(eventVersion)),
+                eventHash,
+                eventPosition: 1111111,
+                throwStaleWhenGone: false,
+                CancellationToken.None);
+
+            Task.WaitAny(new Task[] { result }, ct.Token);
+
+            result.Result.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void WhenVersionsMatch_ButETagMismatch_DoNothing()
+        {
+            var eventHash = "eventHash";
+            var eTag = "eTag";
+
+            var eventVersion = "2022-03-23T14:24:04.801+01:00";
+            var snapshotVersion = "2022-03-23T14:24:04+01:00";
+
+            var ct = new CancellationTokenSource(5000);
+
+            var mockProxy = new Mock<IOsloProxy>();
+            mockProxy.Setup(x => x.GetSnapshot(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new OsloResult
+                {
+                    ETag = eTag,
+                    Identificator = new OsloIdentificator
+                    {
+                        Versie = snapshotVersion
+                    }
+                });
+
+            var snapshotManager = new SnapshotManager(new NullLoggerFactory(), mockProxy.Object, SnapshotManagerOptions.Create("1", "1"));
+            var result = snapshotManager.FindMatchingSnapshot(
+                "50083",
+                Instant.FromDateTimeOffset(DateTimeOffset.Parse(eventVersion)),
+                eventHash,
+                eventPosition: 1111111,
+                throwStaleWhenGone: false,
+                CancellationToken.None);
+
+            Task.WaitAny(new Task[] { result }, ct.Token);
+
+            result.Result.Should().BeNull();
         }
 
         [Fact]
@@ -84,6 +158,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Tests.Oslo
             var result = snapshotManager.FindMatchingSnapshot(
                 "50083",
                 Instant.FromDateTimeOffset(DateTimeOffset.Parse(eventVersion)),
+                null,
                 eventPosition: 1111111,
                 throwStaleWhenGone: false,
                 CancellationToken.None);
@@ -136,6 +211,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Tests.Oslo
             var result = await snapshotManager.FindMatchingSnapshot(
                 "50083",
                 Instant.FromDateTimeOffset(DateTimeOffset.Parse(eventVersion)),
+                null,
                 eventPosition: 1111111,
                 throwStaleWhenGone: false,
                 CancellationToken.None);
@@ -181,6 +257,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Tests.Oslo
             var result = await snapshotManager.FindMatchingSnapshot(
                 "50083",
                 Instant.FromDateTimeOffset(DateTimeOffset.Parse(eventVersion)),
+                null,
                 eventPosition: 1111111,
                 throwStaleWhenGone,
                 CancellationToken.None);
@@ -205,6 +282,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Tests.Oslo
             var result = await snapshotManager.FindMatchingSnapshot(
                 "50083",
                 Instant.FromDateTimeOffset(DateTimeOffset.Parse("2022-03-23T14:24:04+01:00")),
+                null,
                 eventPosition: 1111111,
                 doNotThrowStaleWhenGone,
                 CancellationToken.None);
@@ -262,6 +340,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Tests.Oslo
             await snapshotManager.FindMatchingSnapshot(
                 "50083",
                 Instant.FromDateTimeOffset(DateTimeOffset.Parse(eventVersion)),
+                null,
                 eventPosition: 1111111,
                 throwStaleWhenGone: false,
                 CancellationToken.None);
@@ -282,6 +361,7 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Tests.Oslo
             var act = async () => await snapshotManager.FindMatchingSnapshot(
                 "50083",
                 Instant.FromDateTimeOffset(DateTimeOffset.Parse("2022-03-23T14:24:04+01:00")),
+                null,
                 eventPosition: 1111111,
                 throwStaleWhenGone: false,
                 CancellationToken.None);


### PR DESCRIPTION
BREAKING CHANGE: Add event hash as an extra parameter to ISnapshotManager FindMatchingSnapshot method