### PR TITLE
feat(common): add optional coordinate precision to ConvertToGml

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.GrAr.Common/NetTopology/GeometryExtensions.cs
+++ b/src/Be.Vlaanderen.Basisregisters.GrAr.Common/NetTopology/GeometryExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Be.Vlaanderen.Basisregisters.GrAr.Common.NetTopology;
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Xml;
@@ -35,10 +36,23 @@ public static class GeometryExtensions
         return geometry.ConvertToGml(true);
     }
 
-    public static string ConvertToGml(this Geometry geometry, bool useHttpsSchema)
+    /// <summary>
+    /// Converts the geometry to its GML 3.2 representation.
+    /// </summary>
+    /// <param name="geometry">The geometry to convert.</param>
+    /// <param name="useHttpsSchema">Whether the srsName should use the https schema.</param>
+    /// <param name="coordinatePrecision">
+    /// The number of decimals to use for the coordinate values. When <c>null</c> (the default) the precision is derived
+    /// from the geometry type (2 decimals for a point, 11 for a polygon/multipolygon/linestring); when specified, that
+    /// number of decimals is used instead for every coordinate.
+    /// </param>
+    public static string ConvertToGml(this Geometry geometry, bool useHttpsSchema, int? coordinatePrecision = null)
     {
         if (geometry is null)
             throw new ArgumentNullException(nameof(geometry));
+
+        if (coordinatePrecision is < 0)
+            throw new ArgumentOutOfRangeException(nameof(coordinatePrecision), coordinatePrecision, "Coordinate precision must be greater than or equal to 0.");
 
         if (geometry is not Polygon && geometry is not MultiPolygon && geometry is not LineString && geometry is not Point)
             throw new InvalidOperationException($"Unsupported geometry type: {geometry.GeometryType}. Supported types: Polygon, MultiPolygon, LineString, Point.");
@@ -52,8 +66,8 @@ public static class GeometryExtensions
             {
                 xmlwriter.WriteStartElement("gml", "Polygon", GmlNamespace);
                 WriteSrsName(xmlwriter, geometry, useHttpsSchema);
-                WriteRing((polygon.ExteriorRing as LinearRing)!, xmlwriter);
-                WriteInteriorRings(polygon.InteriorRings, polygon.NumInteriorRings, xmlwriter);
+                WriteRing((polygon.ExteriorRing as LinearRing)!, xmlwriter, coordinatePrecision);
+                WriteInteriorRings(polygon.InteriorRings, polygon.NumInteriorRings, xmlwriter, coordinatePrecision);
                 xmlwriter.WriteEndElement();
             }
         }
@@ -69,8 +83,8 @@ public static class GeometryExtensions
                     xmlwriter.WriteStartElement("gml", "surfaceMember", null!);
                     xmlwriter.WriteStartElement("gml", "Polygon", null!);
 
-                    WriteRing((p.ExteriorRing as LinearRing)!, xmlwriter);
-                    WriteInteriorRings(p.InteriorRings, p.NumInteriorRings, xmlwriter);
+                    WriteRing((p.ExteriorRing as LinearRing)!, xmlwriter, coordinatePrecision);
+                    WriteInteriorRings(p.InteriorRings, p.NumInteriorRings, xmlwriter, coordinatePrecision);
 
                     xmlwriter.WriteEndElement();
                     xmlwriter.WriteEndElement();
@@ -85,7 +99,7 @@ public static class GeometryExtensions
             {
                 xmlwriter.WriteStartElement("gml", "LineString", GmlNamespace);
                 WriteSrsName(xmlwriter, geometry, useHttpsSchema);
-                WritePosList(lineString.Coordinates, xmlwriter);
+                WritePosList(lineString.Coordinates, xmlwriter, coordinatePrecision);
                 xmlwriter.WriteEndElement();
             }
         }
@@ -98,8 +112,8 @@ public static class GeometryExtensions
 
                 xmlwriter.WriteStartElement("gml", "pos", null!);
                 xmlwriter.WriteValue(string.Format(Global.GetNfi(), "{0} {1}",
-                    point.Coordinate.X.ToPointGeometryCoordinateValueFormat(),
-                    point.Coordinate.Y.ToPointGeometryCoordinateValueFormat()));
+                    FormatCoordinate(point.Coordinate.X, coordinatePrecision, static v => v.ToPointGeometryCoordinateValueFormat()),
+                    FormatCoordinate(point.Coordinate.Y, coordinatePrecision, static v => v.ToPointGeometryCoordinateValueFormat())));
                 xmlwriter.WriteEndElement();
 
                 xmlwriter.WriteEndElement();
@@ -127,12 +141,13 @@ public static class GeometryExtensions
     private static void WriteRing(
         LinearRing ring,
         XmlWriter writer,
+        int? coordinatePrecision,
         bool isInterior = false)
     {
         writer.WriteStartElement("gml", isInterior ? "interior" : "exterior", GmlNamespace);
         writer.WriteStartElement("gml", "LinearRing", GmlNamespace);
 
-        WritePosList(ring.Coordinates, writer);
+        WritePosList(ring.Coordinates, writer, coordinatePrecision);
 
         writer.WriteEndElement();
         writer.WriteEndElement();
@@ -141,7 +156,8 @@ public static class GeometryExtensions
     private static void WriteInteriorRings(
         LineString[] rings,
         int numInteriorRings,
-        XmlWriter writer)
+        XmlWriter writer,
+        int? coordinatePrecision)
     {
         if (numInteriorRings < 1)
         {
@@ -150,13 +166,14 @@ public static class GeometryExtensions
 
         foreach (var ring in rings)
         {
-            WriteRing((ring as LinearRing)!, writer, true);
+            WriteRing((ring as LinearRing)!, writer, coordinatePrecision, true);
         }
     }
 
     private static void WritePosList(
         Coordinate[] coordinates,
-        XmlWriter writer)
+        XmlWriter writer,
+        int? coordinatePrecision)
     {
         writer.WriteStartElement("gml", "posList", GmlNamespace);
 
@@ -166,8 +183,8 @@ public static class GeometryExtensions
             posListBuilder.Append(string.Format(
                 Global.GetNfi(),
                 "{0} {1} ",
-                coordinate.X.ToPolygonGeometryCoordinateValueFormat(),
-                coordinate.Y.ToPolygonGeometryCoordinateValueFormat()));
+                FormatCoordinate(coordinate.X, coordinatePrecision, static v => v.ToPolygonGeometryCoordinateValueFormat()),
+                FormatCoordinate(coordinate.Y, coordinatePrecision, static v => v.ToPolygonGeometryCoordinateValueFormat())));
         }
 
         //remove last space
@@ -176,5 +193,14 @@ public static class GeometryExtensions
         writer.WriteValue(posListBuilder.ToString());
 
         writer.WriteEndElement();
+    }
+
+    // Formats a coordinate value: the explicitly requested number of decimals when a coordinate precision is given,
+    // otherwise the geometry-type based default format.
+    private static string FormatCoordinate(double value, int? coordinatePrecision, Func<double, string> defaultFormat)
+    {
+        return coordinatePrecision.HasValue
+            ? value.ToString("F" + coordinatePrecision.Value.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture)
+            : defaultFormat(value);
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.GrAr.Tests/Common/NTS/GeometryExtensionsTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.GrAr.Tests/Common/NTS/GeometryExtensionsTests.cs
@@ -1,5 +1,6 @@
 namespace Be.Vlaanderen.Basisregisters.GrAr.Tests.Common.NTS
 {
+    using System;
     using FluentAssertions;
     using GrAr.Common.NetTopology;
     using NetTopologySuite.Geometries;
@@ -8,6 +9,101 @@ namespace Be.Vlaanderen.Basisregisters.GrAr.Tests.Common.NTS
 
     public class GeometryExtensionsTests
     {
+        [Fact]
+        public void WhenConvertLineStringToGmlWithCoordinatePrecision_ThenCoordinatesUseThatPrecision()
+        {
+            var geometry = new LineString(
+            [
+                new Coordinate(10, 20),
+                new Coordinate(30, 40)
+            ]);
+            geometry.SRID = SystemReferenceId.SridLambert72;
+
+            var resultingGml = geometry.ConvertToGml(true, 2);
+
+            resultingGml.Should().Be(
+                "<gml:LineString srsName=\"https://www.opengis.net/def/crs/EPSG/0/31370\" xmlns:gml=\"http://www.opengis.net/gml/3.2\">" +
+                "<gml:posList>10.00 20.00 30.00 40.00</gml:posList>" +
+                "</gml:LineString>");
+        }
+
+        [Fact]
+        public void WhenConvertLineStringToGmlWithCoordinatePrecisionZero_ThenCoordinatesHaveNoDecimals()
+        {
+            var geometry = new LineString(
+            [
+                new Coordinate(10, 20),
+                new Coordinate(30, 40)
+            ]);
+            geometry.SRID = SystemReferenceId.SridLambert72;
+
+            var resultingGml = geometry.ConvertToGml(true, 0);
+
+            resultingGml.Should().Be(
+                "<gml:LineString srsName=\"https://www.opengis.net/def/crs/EPSG/0/31370\" xmlns:gml=\"http://www.opengis.net/gml/3.2\">" +
+                "<gml:posList>10 20 30 40</gml:posList>" +
+                "</gml:LineString>");
+        }
+
+        [Fact]
+        public void WhenConvertPointToGmlWithCoordinatePrecision_ThenCoordinatesUseThatPrecision()
+        {
+            var geometry = new Point(new Coordinate(1.123456, 2.5)) { SRID = SystemReferenceId.SridLambert72 };
+
+            var resultingGml = geometry.ConvertToGml(true, 5);
+
+            resultingGml.Should().Be(
+                "<gml:Point srsName=\"https://www.opengis.net/def/crs/EPSG/0/31370\" xmlns:gml=\"http://www.opengis.net/gml/3.2\">" +
+                "<gml:pos>1.12346 2.50000</gml:pos>" +
+                "</gml:Point>");
+        }
+
+        [Fact]
+        public void WhenConvertPolygonToGmlWithCoordinatePrecision_ThenCoordinatesUseThatPrecision()
+        {
+            var geometry = new Polygon(new LinearRing(
+            [
+                new Coordinate(0, 0),
+                new Coordinate(0, 10),
+                new Coordinate(10, 10),
+                new Coordinate(10, 0),
+                new Coordinate(0, 0)
+            ]));
+            geometry.SRID = SystemReferenceId.SridLambert72;
+
+            var resultingGml = geometry.ConvertToGml(true, 1);
+
+            resultingGml.Should().Be(
+                "<gml:Polygon srsName=\"https://www.opengis.net/def/crs/EPSG/0/31370\" xmlns:gml=\"http://www.opengis.net/gml/3.2\">" +
+                "<gml:exterior><gml:LinearRing>" +
+                "<gml:posList>0.0 0.0 0.0 10.0 10.0 10.0 10.0 0.0 0.0 0.0</gml:posList>" +
+                "</gml:LinearRing></gml:exterior>" +
+                "</gml:Polygon>");
+        }
+
+        [Fact]
+        public void WhenConvertToGmlWithNullCoordinatePrecision_ThenUsesGeometryTypeBasedPrecision()
+        {
+            var geometry = new LineString(
+            [
+                new Coordinate(10, 20),
+                new Coordinate(30, 40)
+            ]);
+            geometry.SRID = SystemReferenceId.SridLambert72;
+
+            geometry.ConvertToGml(true, null).Should().Be(geometry.ConvertToGml(true));
+        }
+
+        [Fact]
+        public void WhenConvertToGmlWithNegativeCoordinatePrecision_ThenThrows()
+        {
+            var geometry = new Point(new Coordinate(1, 2)) { SRID = SystemReferenceId.SridLambert72 };
+
+            var act = () => geometry.ConvertToGml(true, -1);
+
+            act.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
         [Fact]
         public void WhenConvertPolygonToGml_ThenProduceValidXml()
         {


### PR DESCRIPTION
## What

`ConvertToGml` gains an optional `coordinatePrecision` (`int?`) parameter:

- **`null` (default)** — keeps the current behavior: the precision is derived from the geometry type (2 decimals for a point, 11 for a polygon/multipolygon/linestring).
- **specified** — that number of decimals is used for every coordinate instead (`F{precision}`, invariant culture).
- A negative precision throws `ArgumentOutOfRangeException`.

The precision is threaded through the point and pos-list writers via a small `FormatCoordinate` helper. The existing overloads keep their behavior (`ConvertToGml(geometry)` delegates with the default `null`).

## Tests

Added coverage for: LineString precision 2 and 0, Point precision 5 (rounding), Polygon precision 1, `null` precision equals the default output, and negative precision throwing. All existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)